### PR TITLE
ALS-11850: Use pic-sure-common for HPDS dependencies 

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.9-amazoncorretto-25 AS build
 
-COPY --from=maven_m2_cache / /root/.m2/repository/
+COPY --from=m2_cache / /root/.m2/repository/
 COPY ./ /app
 
 WORKDIR /app

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.9-amazoncorretto-25 AS build
 
-COPY --from=m2_cache / /root/.m2/repository/
+COPY --from=maven_m2_cache / /root/.m2/repository/
 COPY ./ /app
 
 WORKDIR /app

--- a/pom.xml
+++ b/pom.xml
@@ -51,10 +51,11 @@
         </dependency>
 
         <!-- HPDS v3 query model -->
+
         <dependency>
             <groupId>edu.harvard.hms.dbmi.avillach.hpds</groupId>
-            <artifactId>client-api</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <artifactId>pic-sure-hpds-model</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
 
         <!-- PIC-SURE domain model (GeneralQueryRequest, QueryRequest) — only used for the gateway strategy -->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal query model dependency to maintain system compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->